### PR TITLE
Fix result array and free properties enum in js_get_property_names

### DIFF
--- a/src/js.c
+++ b/src/js.c
@@ -4479,9 +4479,11 @@ js_get_property_names(js_env_t *env, js_value_t *object, js_value_t **result) {
   JSValue array = JS_NewArray(env->context);
 
   for (uint32_t i = 0; i < len; i++) {
-    err = JS_SetPropertyUint32(env->context, object->value, i, JS_AtomToValue(env->context, properties[i].atom));
+    err = JS_SetPropertyUint32(env->context, array, i, JS_AtomToValue(env->context, properties[i].atom));
     if (err < 0) goto err;
   }
+
+  JS_FreePropertyEnum(env->context, properties, len);
 
   if (result == NULL) JS_FreeValue(env->context, array);
   else {
@@ -4497,11 +4499,7 @@ js_get_property_names(js_env_t *env, js_value_t *object, js_value_t **result) {
   return 0;
 
 err:
-  for (uint32_t i = 0; i < len; i++) {
-    JS_FreeAtom(env->context, properties[i].atom);
-  }
-
-  free(properties);
+  JS_FreePropertyEnum(env->context, properties, len);
 
   return js__error(env);
 }


### PR DESCRIPTION
Hi,

A couple of changes to `js_get_property_names`:

- The property names get assigned to the passed object. I believe this should instead be the created result array.
- `properties` never get released in the success case.
- `JS_FreePropertyEnum` should do the same as freeing the atoms and properties individually.